### PR TITLE
Set CMAKE_PCH_COMPILER_TARGETS and FLAGS as cache variables

### DIFF
--- a/CMakePCHCompiler.cmake
+++ b/CMakePCHCompiler.cmake
@@ -118,12 +118,12 @@ function(target_precompiled_header) # target [...] header
 			list(APPEND CMAKE_PCH_COMPILER_TARGETS ${target})
 			set(CMAKE_PCH_COMPILER_TARGETS
 				"${CMAKE_PCH_COMPILER_TARGETS}"
-				PARENT_SCOPE
+				CACHE STRING "Target for pch"
 				)
 			list(APPEND CMAKE_PCH_COMPILER_TARGET_FLAGS ${flags})
 			set(CMAKE_PCH_COMPILER_TARGET_FLAGS
 				"${CMAKE_PCH_COMPILER_TARGET_FLAGS}"
-				PARENT_SCOPE
+				CACHE STRING "Flags for target for pch"
 				)
 		endif()
 	endforeach()


### PR DESCRIPTION
PARENT_SCOPE doesn't work if the CMake project uses add_subdirectory. CACHE variables are global. This should fix issue #4.
