### PR TITLE
Fix for NOTFOUND issue in some (or all) cases.

### DIFF
--- a/CMakePCHCompiler.cmake
+++ b/CMakePCHCompiler.cmake
@@ -142,7 +142,7 @@ function(target_precompiled_header) # target [...] header
 				"/FI\"${win_header}\"" 
 				##"/Fd\"${pdb_dir}\\\\\""
 				)			
-			target_link_libraries(${target} ${pch_target})
+			target_link_libraries(${target} PRIVATE ${pch_target})
 		else()
 			#Careful: set_target_properties is destructive
 			target_compile_options(${target} PRIVATE 

--- a/CMakePCHCompiler.cmake
+++ b/CMakePCHCompiler.cmake
@@ -212,36 +212,39 @@ endmacro()
 
 # copies all compile definitions, flags and options to .pch subtarget
 function(__watch_pch_last_hook variable access value)
+
 	list(LENGTH CMAKE_PCH_COMPILER_TARGETS length)
-	foreach(index RANGE -${length} -1)
-		list(GET CMAKE_PCH_COMPILER_TARGETS ${index} target)
-		list(GET CMAKE_PCH_COMPILER_TARGET_FLAGS ${index} flags)
-		set(pch_target ${target}.pch)
-		foreach(property
-			COMPILE_DEFINITIONS
-			COMPILE_DEFINITIONS_DEBUG
-			COMPILE_DEFINITIONS_MINSIZEREL
-			COMPILE_DEFINITIONS_RELEASE
-			COMPILE_DEFINITIONS_RELWITHDEBINFO
-			COMPILE_FLAGS
-			COMPILE_OPTIONS
-			)
-			get_target_property(value ${target} ${property})
-			# remove compile flags that we inserted by
-			# target_precompiled_header
-			if(property STREQUAL "COMPILE_FLAGS")
-				string(REPLACE "${flags}" "" value "${value}")
-			endif()
-			if(NOT value STREQUAL "value-NOTFOUND")
-				set_target_properties(
-					"${pch_target}"
-					PROPERTIES
-					"${property}"
-					"${value}"
-					)
-			endif()
+	if(0!=length)	
+		foreach(index RANGE -${length} -1)
+			list(GET CMAKE_PCH_COMPILER_TARGETS ${index} target)
+			list(GET CMAKE_PCH_COMPILER_TARGET_FLAGS ${index} flags)
+			set(pch_target ${target}.pch)
+			foreach(property
+				COMPILE_DEFINITIONS
+				COMPILE_DEFINITIONS_DEBUG
+				COMPILE_DEFINITIONS_MINSIZEREL
+				COMPILE_DEFINITIONS_RELEASE
+				COMPILE_DEFINITIONS_RELWITHDEBINFO
+				COMPILE_FLAGS
+				COMPILE_OPTIONS
+				)
+				get_target_property(value ${target} ${property})
+				# remove compile flags that we inserted by
+				# target_precompiled_header
+				if(property STREQUAL "COMPILE_FLAGS")
+					string(REPLACE "${flags}" "" value "${value}")
+				endif()
+				if(NOT value STREQUAL "value-NOTFOUND")
+					set_target_properties(
+						"${pch_target}"
+						PROPERTIES
+						"${property}"
+						"${value}"
+						)
+				endif()
+			endforeach()
 		endforeach()
-	endforeach()
+	endif()
 endfunction()
 
 # copies all custom compiler settings to PCH compiler

--- a/CMakePCHCompiler.cmake
+++ b/CMakePCHCompiler.cmake
@@ -59,7 +59,14 @@ function(target_precompiled_header) # target [...] header
 		endif()
 		if(ARGS_REUSE)
 			set(pch_target ${ARGS_REUSE}.pch)
+			set(target_dir
+				${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${pch_target}.dir
+			)
 		else()
+			set(pch_target ${target}.pch)
+			set(target_dir
+				${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${pch_target}.dir
+			)
 			if(ARGS_TYPE)
 				set(header_type ${ARGS_TYPE})
 			elseif(lang STREQUAL C)
@@ -72,40 +79,54 @@ function(target_precompiled_header) # target [...] header
 			endif()
 			if(MSVC)
 				# ensure pdb goes to the same location, otherwise we get C2859
-				file(TO_NATIVE_PATH
-					"${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${target}.dir"
+				get_filename_component(
 					pdb_dir
+					"${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${target}.dir"
+					ABSOLUTE
 					)
+				get_filename_component(win_pch "${target_dir}/${header}.pch" ABSOLUTE)
+				get_filename_component(win_header "${header}" ABSOLUTE)
 				# /Yc - create precompiled header
+				# /Fp - exact location for precompiled header
 				# /Fd - specify directory for pdb output
-				set(flags "/Yc /Fd${pdb_dir}\\")
+				set(flags "/Yc${win_header} /Fp${win_pch} /Fd${pdb_dir}")
+
+				set_source_files_properties(
+					${header}
+					PROPERTIES
+					LANGUAGE ${lang}
+					COMPILE_FLAGS ${flags}
+					)
+
+				add_library(${pch_target} ${header})
 			else()
 				set(flags "-x ${header_type}")
+				set_source_files_properties(
+					${header}
+					PROPERTIES
+					LANGUAGE ${lang}PCH
+					COMPILE_FLAGS ${flags}
+					)
+				add_library(${pch_target} OBJECT ${header})
 			endif()
-			set_source_files_properties(
-				${header}
-				PROPERTIES
-				LANGUAGE ${lang}PCH
-				COMPILE_FLAGS ${flags}
-				)
-			add_library(${target}.pch OBJECT ${header})
-			set(pch_target ${target}.pch)
 		endif()
+
 		add_dependencies(${target} ${pch_target})
-		set(target_dir
-			${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${pch_target}.dir
-			)
+
 		if(MSVC)
-			get_filename_component(win_header "${header}" NAME)
-			file(TO_NATIVE_PATH "${target_dir}/${header}.pch" win_pch)
+			get_filename_component(win_pch "${target_dir}/${header}.pch" ABSOLUTE)
+			get_filename_component(win_header "${header}" ABSOLUTE)
 			# /Yu - use given include as precompiled header
 			# /Fp - exact location for precompiled header
 			# /FI - force include of precompiled header
-			set(flags "/Yu${win_header} /Fp${win_pch} /FI${win_header}")
+			target_compile_options(
+				"${target}" PUBLIC "/Yu${win_header}" "/Fp${win_pch}" "/FI${win_header}"
+				)
+			target_link_libraries(${target} ${pch_target})
 		else()
 			set(flags "-include \"${target_dir}/${header}\"")
+			set_target_properties(${target} PROPERTIES COMPILE_FLAGS "${flags}")
 		endif()
-		set_target_properties(${target} PROPERTIES COMPILE_FLAGS "${flags}")
 
 		if(NOT ARGS_REUSE)
 			if(NOT DEFINED CMAKE_PCH_COMPILER_TARGETS)
@@ -225,16 +246,25 @@ function(__watch_pch_last_hook variable access value)
 				COMPILE_DEFINITIONS_MINSIZEREL
 				COMPILE_DEFINITIONS_RELEASE
 				COMPILE_DEFINITIONS_RELWITHDEBINFO
-				COMPILE_FLAGS
-				COMPILE_OPTIONS
-				)
-				get_target_property(value ${target} ${property})
-				# remove compile flags that we inserted by
-				# target_precompiled_header
-				if(property STREQUAL "COMPILE_FLAGS")
-					string(REPLACE "${flags}" "" value "${value}")
-				endif()
-				if(NOT value STREQUAL "value-NOTFOUND")
+			COMPILE_OPTIONS
+			INCLUDE_DIRECTORIES
+			CXX_STANDARD
+			)
+			get_target_property(value ${target} ${property})
+			# remove compile flags that we inserted by
+			# target_precompiled_header
+			if(property STREQUAL "COMPILE_FLAGS")
+				string(REPLACE "${flags}" "" value "${value}")
+			endif()
+			if(NOT value STREQUAL "value-NOTFOUND")
+				if(property STREQUAL "CXX_STANDARD")
+					if(NOT MSVC)
+						target_compile_options(
+							"${pch_target}"
+							PUBLIC "-std=gnu++${value}"
+							)
+					endif()
+				else()
 					set_target_properties(
 						"${pch_target}"
 						PROPERTIES
@@ -242,7 +272,7 @@ function(__watch_pch_last_hook variable access value)
 						"${value}"
 						)
 				endif()
-			endforeach()
+			endif()
 		endforeach()
 	endif()
 endfunction()

--- a/CMakePCHCompiler.cmake
+++ b/CMakePCHCompiler.cmake
@@ -103,7 +103,7 @@ function(target_precompiled_header) # target [...] header
 			# /FI - force include of precompiled header
 			set(flags "/Yu${win_header} /Fp${win_pch} /FI${win_header}")
 		else()
-			set(flags "-include ${target_dir}/${header}")
+			set(flags "-include \"${target_dir}/${header}\"")
 		endif()
 		set_target_properties(${target} PROPERTIES COMPILE_FLAGS "${flags}")
 

--- a/CMakePCHCompiler.cmake
+++ b/CMakePCHCompiler.cmake
@@ -89,7 +89,7 @@ function(target_precompiled_header) # target [...] header
 				# /Yc - create precompiled header
 				# /Fp - exact location for precompiled header
 				# /Fd - specify directory for pdb output
-				set(flags "/Yc${win_header} /Fp${win_pch} /Fd${pdb_dir}")
+				set(flags "/Yc\"${win_header}\" /Fp\"${win_pch}\" /Fd\"${pdb_dir}\"")
 
 				set_source_files_properties(
 					${header}
@@ -120,7 +120,7 @@ function(target_precompiled_header) # target [...] header
 			# /Fp - exact location for precompiled header
 			# /FI - force include of precompiled header
 			target_compile_options(
-				"${target}" PUBLIC "/Yu${win_header}" "/Fp${win_pch}" "/FI${win_header}"
+				"${target}" PUBLIC "/Yu\"${win_header}\"" "/Fp\"${win_pch}\"" "/FI\"${win_header}\""
 				)
 			target_link_libraries(${target} ${pch_target})
 		else()


### PR DESCRIPTION
Check that the CMAKE_PCH_COMPILER_TARGETS is not empty.

You may not want to indent this, or might know how to fix the RANGE parameters instead. I'm new to Github and CMake. 

In a nontrivial project tree the root may not have any targets, and some of the sub-directories might not use precompiled headers.

This appears to work for one precompiled header in one sub-directory. I will be back if sub-directories clash.