### PR TITLE
Nanoant pull request

### DIFF
--- a/CMakePCHCompiler.cmake
+++ b/CMakePCHCompiler.cmake
@@ -142,7 +142,7 @@ function(target_precompiled_header) # target [...] header
 				"/FI\"${win_header}\"" 
 				##"/Fd\"${pdb_dir}\\\\\""
 				)			
-			target_link_libraries(${target} ${pch_target})
+			target_link_libraries(${target} PRIVATE ${pch_target})
 		else()
 			#Careful: set_target_properties is destructive
 			target_compile_options(${target} PRIVATE 

--- a/CMakePCHCompiler.cmake
+++ b/CMakePCHCompiler.cmake
@@ -68,13 +68,7 @@ function(target_precompiled_header) # target [...] header
 				${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${pch_target}.dir
 			)
 		endif()
-		if(MSVC)
-			# ensure pdb goes to the same location, otherwise we get C2859
-			get_filename_component(
-				pdb_dir
-				"${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${target}.dir"
-				ABSOLUTE
-				)
+		if(MSVC)			
 			get_filename_component(win_pch "${target_dir}/${header}.pch" ABSOLUTE)
 			get_filename_component(win_header "${header}" ABSOLUTE)		
 		endif()

--- a/CMakePCHCompiler.cmake
+++ b/CMakePCHCompiler.cmake
@@ -212,36 +212,39 @@ endmacro()
 
 # copies all compile definitions, flags and options to .pch subtarget
 function(__watch_pch_last_hook variable access value)
+
 	list(LENGTH CMAKE_PCH_COMPILER_TARGETS length)
-	foreach(index RANGE -${length} -1)
-		list(GET CMAKE_PCH_COMPILER_TARGETS ${index} target)
-		list(GET CMAKE_PCH_COMPILER_TARGET_FLAGS ${index} flags)
-		set(pch_target ${target}.pch)
-		foreach(property
-			COMPILE_DEFINITIONS
-			COMPILE_DEFINITIONS_DEBUG
-			COMPILE_DEFINITIONS_MINSIZEREL
-			COMPILE_DEFINITIONS_RELEASE
-			COMPILE_DEFINITIONS_RELWITHDEBINFO
-			COMPILE_FLAGS
-			COMPILE_OPTIONS
-			)
-			get_target_property(value ${target} ${property})
-			# remove compile flags that we inserted by
-			# target_precompiled_header
-			if(property STREQUAL "COMPILE_FLAGS")
-				string(REPLACE "${flags}" "" value "${value}")
-			endif()
-			if(NOT value STREQUAL "value-NOTFOUND")
-				set_target_properties(
-					"${pch_target}"
-					PROPERTIES
-					"${property}"
-					"${value}"
-					)
-			endif()
+	if(0!=length)	
+		foreach(index RANGE -${length} -1)
+			list(GET CMAKE_PCH_COMPILER_TARGETS ${index} target)
+			list(GET CMAKE_PCH_COMPILER_TARGET_FLAGS ${index} flags)
+			set(pch_target ${target}.pch)
+			foreach(property
+				COMPILE_DEFINITIONS
+				COMPILE_DEFINITIONS_DEBUG
+				COMPILE_DEFINITIONS_MINSIZEREL
+				COMPILE_DEFINITIONS_RELEASE
+				COMPILE_DEFINITIONS_RELWITHDEBINFO
+				COMPILE_FLAGS
+				COMPILE_OPTIONS
+				)
+				get_target_property(value ${target} ${property})
+				# remove compile flags that we inserted by
+				# target_precompiled_header
+				if(property STREQUAL "COMPILE_FLAGS")
+					string(REPLACE "${flags}" "" value "${value}")
+				endif()
+				if(NOT value STREQUAL "value-NOTFOUND")
+					set_target_properties(
+						"${pch_target}"
+						PROPERTIES
+						"${property}"
+						"${value}"
+						)
+				endif()
+			endforeach()
 		endforeach()
-	endforeach()
+	endif()
 endfunction()
 
 # copies all custom compiler settings to PCH compiler

--- a/CMakePCHCompiler.cmake
+++ b/CMakePCHCompiler.cmake
@@ -59,7 +59,14 @@ function(target_precompiled_header) # target [...] header
 		endif()
 		if(ARGS_REUSE)
 			set(pch_target ${ARGS_REUSE}.pch)
+			set(target_dir
+				${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${pch_target}.dir
+			)
 		else()
+			set(pch_target ${target}.pch)
+			set(target_dir
+				${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${pch_target}.dir
+			)
 			if(ARGS_TYPE)
 				set(header_type ${ARGS_TYPE})
 			elseif(lang STREQUAL C)
@@ -72,40 +79,54 @@ function(target_precompiled_header) # target [...] header
 			endif()
 			if(MSVC)
 				# ensure pdb goes to the same location, otherwise we get C2859
-				file(TO_NATIVE_PATH
-					"${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${target}.dir"
+				get_filename_component(
 					pdb_dir
+					"${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${target}.dir"
+					ABSOLUTE
 					)
+				get_filename_component(win_pch "${target_dir}/${header}.pch" ABSOLUTE)
+				get_filename_component(win_header "${header}" ABSOLUTE)
 				# /Yc - create precompiled header
+				# /Fp - exact location for precompiled header
 				# /Fd - specify directory for pdb output
-				set(flags "/Yc /Fd${pdb_dir}\\")
+				set(flags "/Yc${win_header} /Fp${win_pch} /Fd${pdb_dir}")
+
+				set_source_files_properties(
+					${header}
+					PROPERTIES
+					LANGUAGE ${lang}
+					COMPILE_FLAGS ${flags}
+					)
+
+				add_library(${pch_target} ${header})
 			else()
 				set(flags "-x ${header_type}")
+				set_source_files_properties(
+					${header}
+					PROPERTIES
+					LANGUAGE ${lang}PCH
+					COMPILE_FLAGS ${flags}
+					)
+				add_library(${pch_target} OBJECT ${header})
 			endif()
-			set_source_files_properties(
-				${header}
-				PROPERTIES
-				LANGUAGE ${lang}PCH
-				COMPILE_FLAGS ${flags}
-				)
-			add_library(${target}.pch OBJECT ${header})
-			set(pch_target ${target}.pch)
 		endif()
+
 		add_dependencies(${target} ${pch_target})
-		set(target_dir
-			${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${pch_target}.dir
-			)
+
 		if(MSVC)
-			get_filename_component(win_header "${header}" NAME)
-			file(TO_NATIVE_PATH "${target_dir}/${header}.pch" win_pch)
+			get_filename_component(win_pch "${target_dir}/${header}.pch" ABSOLUTE)
+			get_filename_component(win_header "${header}" ABSOLUTE)
 			# /Yu - use given include as precompiled header
 			# /Fp - exact location for precompiled header
 			# /FI - force include of precompiled header
-			set(flags "/Yu${win_header} /Fp${win_pch} /FI${win_header}")
+			target_compile_options(
+				"${target}" PUBLIC "/Yu${win_header}" "/Fp${win_pch}" "/FI${win_header}"
+				)
+			target_link_libraries(${target} ${pch_target})
 		else()
 			set(flags "-include \"${target_dir}/${header}\"")
+			set_target_properties(${target} PROPERTIES COMPILE_FLAGS "${flags}")
 		endif()
-		set_target_properties(${target} PROPERTIES COMPILE_FLAGS "${flags}")
 
 		if(NOT ARGS_REUSE)
 			if(NOT DEFINED CMAKE_PCH_COMPILER_TARGETS)
@@ -225,16 +246,25 @@ function(__watch_pch_last_hook variable access value)
 				COMPILE_DEFINITIONS_MINSIZEREL
 				COMPILE_DEFINITIONS_RELEASE
 				COMPILE_DEFINITIONS_RELWITHDEBINFO
-				COMPILE_FLAGS
-				COMPILE_OPTIONS
-				)
-				get_target_property(value ${target} ${property})
-				# remove compile flags that we inserted by
-				# target_precompiled_header
-				if(property STREQUAL "COMPILE_FLAGS")
-					string(REPLACE "${flags}" "" value "${value}")
-				endif()
-				if(NOT value STREQUAL "value-NOTFOUND")
+			COMPILE_OPTIONS
+			INCLUDE_DIRECTORIES
+			CXX_STANDARD
+			)
+			get_target_property(value ${target} ${property})
+			# remove compile flags that we inserted by
+			# target_precompiled_header
+			if(property STREQUAL "COMPILE_FLAGS")
+				string(REPLACE "${flags}" "" value "${value}")
+			endif()
+			if(NOT value STREQUAL "value-NOTFOUND")
+				if(property STREQUAL "CXX_STANDARD")
+					if(NOT MSVC)
+						target_compile_options(
+							"${pch_target}"
+							PUBLIC "-std=gnu++${value}"
+							)
+					endif()
+				else()
 					set_target_properties(
 						"${pch_target}"
 						PROPERTIES
@@ -242,7 +272,7 @@ function(__watch_pch_last_hook variable access value)
 						"${value}"
 						)
 				endif()
-			endforeach()
+			endif()
 		endforeach()
 	endif()
 endfunction()

--- a/CMakePCHCompiler.cmake
+++ b/CMakePCHCompiler.cmake
@@ -103,7 +103,7 @@ function(target_precompiled_header) # target [...] header
 			# /FI - force include of precompiled header
 			set(flags "/Yu${win_header} /Fp${win_pch} /FI${win_header}")
 		else()
-			set(flags "-include ${target_dir}/${header}")
+			set(flags "-include \"${target_dir}/${header}\"")
 		endif()
 		set_target_properties(${target} PROPERTIES COMPILE_FLAGS "${flags}")
 

--- a/CMakePCHCompiler.cmake
+++ b/CMakePCHCompiler.cmake
@@ -89,7 +89,7 @@ function(target_precompiled_header) # target [...] header
 				# /Yc - create precompiled header
 				# /Fp - exact location for precompiled header
 				# /Fd - specify directory for pdb output
-				set(flags "/Yc${win_header} /Fp${win_pch} /Fd${pdb_dir}")
+				set(flags "/Yc\"${win_header}\" /Fp\"${win_pch}\" /Fd\"${pdb_dir}\"")
 
 				set_source_files_properties(
 					${header}
@@ -120,7 +120,7 @@ function(target_precompiled_header) # target [...] header
 			# /Fp - exact location for precompiled header
 			# /FI - force include of precompiled header
 			target_compile_options(
-				"${target}" PUBLIC "/Yu${win_header}" "/Fp${win_pch}" "/FI${win_header}"
+				"${target}" PUBLIC "/Yu\"${win_header}\"" "/Fp\"${win_pch}\"" "/FI\"${win_header}\""
 				)
 			target_link_libraries(${target} ${pch_target})
 		else()


### PR DESCRIPTION
Hi! 

I think I've finally straightened everything out. It's almost impossible to go over everything here. Luckily after so many extensive changes this PR is saying "Able to merge" so I think it's good to just go with it.

Some reservations: I think it would be better if the PCH file went into the binary folders in the MSVC targets, but I don't know how to do that. Currently it goes into the CMakeFiles folders, and it's not release/debug specific, so a clean is probably needed to switch from debug to release, etc. This is nothing new. (Also including headers in the target is not practical. Under GCC it won't work, and I'm unsure about MSVC, but in general, the module cannot consider this use case, and users must accept this limitation. End-users can include the headers themselves I think, manually. But CMake conflates headers with sources, and the custom PCH compilers collide with CMake's naive approach.)

https://github.com/nanoant/CMakePCHCompiler/issues/7

Because of code in an MSVC script file, called Microsoft.Cpp.Win32.targets, the old way would not normally work on MSVC2010 forward. I worked on many things (paths with spaces, install(EXPORT), and so on) that I can't all recollect before getting to the final step, only to not be able to build under MSVC. 

Today I tried some things based on readings, and made it work by forcing /Z7 and including the OBJ outputted by the PCH target in the target sources. This is a straightforward fix compared to using /Zi and PDB and avoids PDB altogether, which was an additional synchronization problem before. Currently only the PCH/GCH files must be referred to by their naked paths. I'd love it if $<TARGET_OBJECTS> worked for all purposes, but I'm pretty sure that it doesn't. I may explore this and file a feature-request with CMake if to no avail.

I've had the opportunity to better understand the module after spending so much time struggling to make it work in a real cross-platform use-case. So I've also made many nuanced improvements along the way, to I think, make it easier to understand. There were some unexplained sly tricks, which I've not added comments on, but have duplicated and changed the names of some variables to better communicate their intent.

https://github.com/nanoant/CMakePCHCompiler/issues/4

Also in this is a fix for the outstanding NOTFOUND issue, which is actually where my work began, before getting sucked down the proverbial rabbit hole. I don't know if this simple fix will solve everyone's NOTFOUND issue, but it solved mine, and I expect it will solve many if not all's.

This MSVC fix preserves the REUSE feature, although I've not tested it. To MSVC the PCH is always technically reused, because it's shared by the project-module that generates it and the consuming module. The way CMakePCHCompiler works (its workflow) is really not consistent with MSVC, but I prefer to code it this way, so that it follows the same beats as the GCH pathway; and in fact, if it diverged into the more natural MSVC approach, the REUSE option might otherwise not have worked, or would not be practical. So this is a happy ending.

In any case, this works for me, and I can't think of anything to change off the top of my head :)