### PR TITLE
Add CMake 3.12 compatibility

### DIFF
--- a/CMakePCHCompiler.cmake
+++ b/CMakePCHCompiler.cmake
@@ -174,9 +174,15 @@ macro(__define_pch_compiler lang)
 
 	# setup compiler & platform specific flags same way C/CXX does
 	if(CMAKE_${lang}_COMPILER_ID)
-		include(Platform/${CMAKE_SYSTEM_NAME}-${CMAKE_${lang}_COMPILER_ID}-${lang}PCH
-			OPTIONAL
-			)
+		if(CMAKE_VERSION VERSION_LESS 3.12)
+			include(Platform/${CMAKE_SYSTEM_NAME}-${CMAKE_${lang}_COMPILER_ID}-${lang}PCH
+				OPTIONAL
+				)
+		else()
+			include(Platform/${CMAKE_EFFECTIVE_SYSTEM_NAME}-${CMAKE_${lang}_COMPILER_ID}-${lang}PCH
+				OPTIONAL
+				)
+		endif()
 	endif()
 
 	# just use all settings from C/CXX compiler

--- a/Platform/Apple-AppleClang-CXXPCH.cmake
+++ b/Platform/Apple-AppleClang-CXXPCH.cmake
@@ -1,0 +1,1 @@
+include(Platform/Apple-Clang-CXXPCH)

--- a/Platform/Apple-Clang-CPCH.cmake
+++ b/Platform/Apple-Clang-CPCH.cmake
@@ -1,0 +1,2 @@
+include(Platform/Apple-Clang)
+__apple_compiler_clang(CPCH)

--- a/Platform/Apple-Clang-CXXPCH.cmake
+++ b/Platform/Apple-Clang-CXXPCH.cmake
@@ -1,0 +1,2 @@
+include(Platform/Apple-Clang)
+__apple_compiler_clang(CXXPCH)

--- a/Platform/Apple-GNU-CPCH.cmake
+++ b/Platform/Apple-GNU-CPCH.cmake
@@ -1,0 +1,4 @@
+include(Platform/Apple-GNU)
+__apple_compiler_gnu(CPCH)
+cmake_gnu_set_sysroot_flag(CPCH)
+cmake_gnu_set_osx_deployment_target_flag(CPCH)

--- a/Platform/Apple-GNU-CXXPCH.cmake
+++ b/Platform/Apple-GNU-CXXPCH.cmake
@@ -1,0 +1,4 @@
+include(Platform/Apple-GNU)
+__apple_compiler_gnu(CXXPCH)
+cmake_gnu_set_sysroot_flag(CXXPCH)
+cmake_gnu_set_osx_deployment_target_flag(CXXPCH)

--- a/Platform/Apple-Intel-CPCH.cmake
+++ b/Platform/Apple-Intel-CPCH.cmake
@@ -1,0 +1,2 @@
+include(Platform/Apple-Intel)
+__apple_compiler_intel(CPCH)

--- a/Platform/Apple-Intel-CXXPCH.cmake
+++ b/Platform/Apple-Intel-CXXPCH.cmake
@@ -1,0 +1,2 @@
+include(Platform/Apple-Intel)
+__apple_compiler_intel(CXXPCH)


### PR DESCRIPTION
In CMake 3.12 you have to use `CMAKE_EFFECTIVE_SYSTEM_NAME` for including Platform files. Also internally `Darwin` files got renamed to `Apple`.