### PR TITLE
Pull LINK_LIBRARIES property from target to pch_target.

### DIFF
--- a/CMakePCHCompiler.cmake
+++ b/CMakePCHCompiler.cmake
@@ -106,6 +106,9 @@ function(target_precompiled_header) # target [...] header
 			endif()
 		endif()
 
+		get_target_property(target_libraries ${target} LINK_LIBRARIES)
+		set_target_properties(${pch_target} PROPERTIES LINK_LIBRARIES "${target_libraries}")
+
 		add_dependencies(${target} ${pch_target})
 
 		if(MSVC)


### PR DESCRIPTION
This resolves #25 on my QT5 project.

Tested with cmake 3.13.3 and gcc 8.2.0.