### PR TITLE
Remove cyclic dependency of pch target

### DIFF
--- a/CMakePCHCompiler.cmake
+++ b/CMakePCHCompiler.cmake
@@ -107,7 +107,9 @@ function(target_precompiled_header) # target [...] header
 		endif()
 
 		get_target_property(target_libraries ${target} LINK_LIBRARIES)
-		set_target_properties(${pch_target} PROPERTIES LINK_LIBRARIES "${target_libraries}")
+		if (NOT ARGS_REUSE)
+			set_target_properties(${pch_target} PROPERTIES LINK_LIBRARIES "${target_libraries}")
+		endif()
 
 		add_dependencies(${target} ${pch_target})
 


### PR DESCRIPTION
Resolves https://github.com/nanoant/CMakePCHCompiler/issues/29
The dependency of the pch on the original target defined it is removed as it is not needed